### PR TITLE
Move Babel config to .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015", "react"],
+  "plugins": ["add-module-exports", "react-html-attrs", "transform-class-properties", "transform-decorators-legacy"]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,11 +9,7 @@ module.exports = {
       {
         test: /\.js?$/,
         exclude: /node_modules/,
-        loader: 'babel-loader',
-        query: {
-          presets: ['react', 'es2015'],
-          plugins: ['react-html-attrs', 'transform-class-properties', 'transform-decorators-legacy']
-        }
+        loader: 'babel-loader'
       },
       {
         test: /\.css$/,


### PR DESCRIPTION
@maneeshanand Please review. This just moves the Babel config info to `.babelrc`